### PR TITLE
Upgrade packages and switch to std::time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rpassword = "4.0"
 
 [dev-dependencies]
 tempdir = "0.3"
-rand = "0.4"
+rand = "0.7"
 bencher = "0.1"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websession"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Jeff Olhoeft <jolhoeft@gmail.com>", "Ben Stern <bas-github@bstern.org>"]
 description = "Web Session Support for Rust"
 license = "MIT/Apache-2.0"
@@ -9,15 +9,14 @@ exclude = ["data/passwd.old"]
 
 [dependencies]
 hyper = { version = "0.10", optional = true }
-pwhash = "^0.2"
-uuid = { version = "0.6", features = [ "v4" ] }
+pwhash = "^0.3"
+uuid = { version = "0.8", features = [ "v4" ] }
 libc = "0.2"
-time = "0.1"
 rust-crypto = "^0.2"
 fs2 = "0.4"
 log = "0.4"
 clap = "2.27"
-rpassword = "2.0"
+rpassword = "4.0"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/backingstore.rs
+++ b/src/backingstore.rs
@@ -729,9 +729,9 @@ mod test {
             Examine,
             Verify,
         }
-        impl rand::Rand for Things {
-            fn rand<R: Rng>(rng: &mut R) -> Self {
-                match rng.gen_range(0, 7) {
+        impl Things {
+            fn random() -> Self {
+                match rand::thread_rng().gen_range(0, 7) {
                     0 => Things::Add,
                     1 => Things::Lock,
                     2 => Things::Unlock,
@@ -745,7 +745,7 @@ mod test {
 
         for _ in [ 1 .. 10 ].iter() {
             for (i, x) in names.iter().enumerate() {
-                match rand::random::<Things>() {
+                match Things::random() {
                     Things::Add => if added.contains(&x.as_str()) {
                         assert_eq!(fbs.create_plain(&x, &passwords[i]), Err(BackingStoreError::UserExists));
                     } else {

--- a/src/bin/simple.rs
+++ b/src/bin/simple.rs
@@ -1,19 +1,18 @@
 extern crate websession;
-extern crate time;
 
 use websession::Authenticator;
 use websession::backingstore::FileBackingStore;
 use websession::sessionpolicy::SessionPolicy;
 use websession::connectionsignature::ConnectionSignature;
-use time::Duration;
+use std::time::Duration;
 
 fn main() {
     let policy = SessionPolicy::new("console");
 
     let authmgr = Authenticator::new(
-	    Box::new(FileBackingStore::new("data/passwd")),
-        Duration::seconds(3600), policy);
-
+	Box::new(FileBackingStore::new("data/passwd")),
+        Duration::from_secs(3600), policy);
+    
     // These normally comes from something like a hyper header, but whatever
     let signature = ConnectionSignature::new("sekrit");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@
 //! ## Example
 //!
 //! See the tests for examples of use.
-extern crate time;
 extern crate uuid;
 #[cfg(feature = "hyper")]
 extern crate hyper;
@@ -29,7 +28,7 @@ pub mod sessionpolicy;
 pub use self::connectionsignature::ConnectionSignature;
 
 use std::collections::HashMap;
-use time::Duration;
+use std::time::Duration;
 use std::error::Error;
 use std::{fmt, io};
 use std::sync::Mutex;

--- a/src/ws_mgr.rs
+++ b/src/ws_mgr.rs
@@ -1,9 +1,8 @@
 extern crate websession;
 extern crate clap;
 extern crate rpassword;
-extern crate time;
 
-use time::Duration;
+use std::time::Duration;
 use rpassword::prompt_password_stdout;
 use websession::{Authenticator, SessionPolicy};
 use websession::backingstore::FileBackingStore;
@@ -70,7 +69,7 @@ pub fn main() {
     let session_policy = SessionPolicy::new(&session_salt);
     let authenticator =
         Authenticator::new(Box::new(FileBackingStore::new("./data/passwd")),
-        Duration::hours(1), session_policy);
+        Duration::from_secs(3600), session_policy);
 
     match matches.subcommand() {
         (ADDUSER, Some(idm)) => {


### PR DESCRIPTION
This switches to use std::time since the time crate has changed a lot. This removes one dependency completely. Also updates a number of packages. I've incremented the version, since this changes the API.